### PR TITLE
feat: update function call to set pizza variable for case statements

### DIFF
--- a/examples/test_case.poo
+++ b/examples/test_case.poo
@@ -1,0 +1,32 @@
+// test_case.poo - case文のテスト
+
+// 基本的なcase文のテスト
+func test_basic_case(num) {
+  case 🍕 % 3 == 0:
+    "Divisible by 3" >> 💩
+  case 🍕 % 5 == 0:
+    "Divisible by 5" >> 💩
+  case default:
+    "Not divisible by 3 or 5" >> 💩
+}
+
+// FizzBuzzをcase文で実装
+func fizzbuzz(num) {
+  case 🍕 % 15 == 0:
+    "FizzBuzz" >> 💩
+  case 🍕 % 3 == 0:
+    "Fizz" >> 💩
+  case 🍕 % 5 == 0:
+    "Buzz" >> 💩
+  case default:
+    🍕 >> 💩
+}
+
+// テスト実行
+"===== 基本的なcase文のテスト =====" |> print
+3 |> test_basic_case |> print  // "Divisible by 3"を表示
+5 |> test_basic_case |> print  // "Divisible by 5"を表示
+7 |> test_basic_case |> print  // "Not divisible by 3 or 5"を表示
+
+"===== FizzBuzzのテスト =====" |> print
+1..20 |> map fizzbuzz |> print  // 1から20までのFizzBuzz

--- a/src/evaluator/pipeline_eval_map_filter.go
+++ b/src/evaluator/pipeline_eval_map_filter.go
@@ -153,9 +153,10 @@ func evalMapOperation(node *ast.InfixExpression, env *object.Environment) object
 			return createError("関数 '%s' が見つかりません", funcName)
 		}
 		
-		// 関数を適用
+		// 関数を適用 (case文サポート)
 		logger.Debug("要素 %s に対して関数 %s を適用", elem.Inspect(), funcName)
-		result := applyFunctionWithPizza(functions[0], args)
+		logCaseDebug("map演算子: case文対応で関数 %s を呼び出します", funcName)
+		result := applyCaseBare(functions[0], args)
 		
 		if result == nil || result.Type() == object.ERROR_OBJ {
 			logger.Debug("関数 %s の適用中にエラーが発生: %s", funcName, result.Inspect())
@@ -297,9 +298,10 @@ func evalFilterOperation(node *ast.InfixExpression, env *object.Environment) obj
 			return createError("関数 '%s' が見つかりません", funcName)
 		}
 		
-		// 関数を適用
+		// 関数を適用 (case文サポート)
 		logger.Debug("要素 %s に対して関数 %s を適用", elem.Inspect(), funcName)
-		result := applyFunctionWithPizza(functions[0], args)
+		logCaseDebug("filter演算子: case文対応で関数 %s を呼び出します", funcName)
+		result := applyCaseBare(functions[0], args)
 		
 		if result == nil || result.Type() == object.ERROR_OBJ {
 			logger.Debug("関数 %s の適用中にエラーが発生: %s", funcName, result.Inspect())


### PR DESCRIPTION
## 概要
Issue #13 の実装として、関数呼び出し時の🍕変数の設定処理を修正し、case文で🍕変数を参照できるようにしました。

## 実装内容
1. `function_basic.go` に `applyCaseBare` 関数を追加
   - 関数呼び出し時に🍕変数を明示的に設定する処理
   - 共通化された関数呼び出し処理

2. `function_named.go` の修正
   - `applyFunctionWithPizza` を `applyCaseBare` に委譲
   - 条件付き関数の適用処理で `applyCaseBare` を使用するよう修正

3. `pipeline_eval_map_filter.go` の修正
   - map演算子とfilter演算子の関数適用処理で `applyCaseBare` を使用するよう修正
   - デバッグログの強化

4. テストファイルの追加
   - `examples/test_case.poo` に基本的なcase文のテストとFizzBuzzの実装例を追加

## 動作確認
- ビルドが正常に完了することを確認
- テスト実行は関連するissue（AST定義、パーサーなど）の実装完了後に行う予定

## 関連issue
#7 - if節の仕様変更
#8 - [Issue #7] トークン定義: CASEとDEFAULTトークンの追加
#9 - [Issue #7] AST: CaseStatement構造体の追加
#10 - [Issue #7] パーサー: case文のパース機能追加
#11 - [Issue #7] 評価器: case_eval.go モジュールの作成
#12 - [Issue #7] 評価器: メインEvaluation関数の拡張
#13 - [Issue #7] 関数呼び出し: 🍕変数の設定処理修正
#14 - [Issue #7] テスト追加: case文のテストケース実装